### PR TITLE
integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,8 +69,9 @@ group :test do
   gem 'rails-controller-testing'
 
   gem 'selenium-webdriver'
-end
-group :test do
+
   gem 'factory_bot_rails'
+
 end
+
 gem 'will_paginate'

--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,7 @@ group :test do
 
   gem 'selenium-webdriver'
 end
+group :test do
+  gem 'factory_bot_rails'
+end
+gem 'will_paginate'

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ group :test do
   gem 'selenium-webdriver'
 
   gem 'factory_bot_rails'
-
 end
 
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,11 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    factory_bot (6.4.5)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -278,6 +283,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -290,6 +296,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  factory_bot_rails
   importmap-rails
   jbuilder
   pg (~> 1.1)
@@ -304,6 +311,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  will_paginate
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Ruby on Rails Visual Studia C
 
 In order to use this project.. Clone this repository to your desired folder by pasting this command in your command line interface:
 
-  https://https://github.com/Surafels/Blog-app.git
+  https://github.com/Surafels/Blog-app.git
 
 ### Prerequisites <a name="prerequisites"></a>
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ rspec
   👤 **Surafel Samson**
 - GitHub: [@githubhandle](https://github.com/Surafels)
 - Twitter: [@twitterhandle](https://twitter.com/SurafelSamson2)
-- GitHub: [@githubhandle](https://github.com/Sami-ullah-tufail)
+
   
   👤 **Burhan Uddin**
 - GitHub: [@githubhandle](https://github.com/bhobserver)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ rspec
 - GitHub: [@githubhandle](https://github.com/Surafels)
 - Twitter: [@twitterhandle](https://twitter.com/SurafelSamson2)
 - GitHub: [@githubhandle](https://github.com/Sami-ullah-tufail)
+  
+  👤 **Burhan Uddin**
+- GitHub: [@githubhandle](https://github.com/bhobserver)
    
 
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,8 @@
 class PostsController < ApplicationController
   def index
     @user = User.find_by_id(params[:user_id])
-    @posts = @user.posts.includes(:comments) if @user
+    # @posts = @user.posts.includes(:comments) if @user
+    @posts = @user.posts.includes(:comments).paginate(page: params[:page], per_page: 3) if @user
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
     @user = User.find_by_id(params[:user_id])
-    @posts = @user.posts if @user
+    @posts = @user.posts.includes(:comments) if @user
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def index
     @users = User.all
+    # @users = User.paginate(page: params[:page])
   end
 
   def show

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -26,7 +26,7 @@
             <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary' %>
         </div>
 
-<% post.most_recent_comments.each do |comment|%>
+<% post.most_recent_comments.includes(:author).each do |comment|%>
 <div class="card mb-2">
     <div class="card-body">
         <p class="card-text"><%= comment.user.name%> :<%= comment.text%></p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -26,7 +26,7 @@
             <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary' %>
         </div>
 
-<% post.most_recent_comments.includes(:author).each do |comment|%>
+<% post.most_recent_comments.includes(:user).each do |comment|%>
 <div class="card mb-2">
     <div class="card-body">
         <p class="card-text"><%= comment.user.name%> :<%= comment.text%></p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,7 +14,7 @@
 <% if @posts.present? %>
 <% @posts.each do |post|%>
 <div class="card mb-2">
-    <%= link_to  user_path(@user, post), class: 'col-md-8 no-link' do %>
+    <%= link_to  user_post_path(@user, post), class: 'col-md-8 no-link' do %>
     <div class="card-body">
         <h5 class="card-title"><%= post.title%></h5>
         <% end %>
@@ -40,6 +40,7 @@
         <%= link_to 'Create New Post', new_user_post_path(user_id: @user.id) , class: 'btn btn-success' %>
     </div>
 
+<%= will_paginate @posts %>
     <% else %>
 
     <p>There is no posts for this user</p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
 
   <div class="card mb-2">
     <div class="card-body">
-      <% @post.comments.each do |comment| %>
+      <% @post.comments.includes(:author).each do |comment| %>
         <p class="card-text"><%= comment.user.name %>: <%= comment.text %></p>
       <% end %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
 
   <div class="card mb-2">
     <div class="card-body">
-      <% @post.comments.includes(:author).each do |comment| %>
+      <% @post.comments.includes(:user).each do |comment| %>
         <p class="card-text"><%= comment.user.name %>: <%= comment.text %></p>
       <% end %>
     </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,3 +20,4 @@
 </div>
 <% end %>
 <% end %>
+<%<%= will_paginate @users %> 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,7 +43,7 @@
   <button type="button" class="btn btn-primary">See all posts</button>
   </div>
 <% end %>
-
+</div>
       <% else %>
       <p>There is no posts</p>
       <% end %>

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_content(@user1.name)
     end
+    it "should display the user's number of posts" do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@user1.posts_counter)
+    end
+    it "should display the post's title" do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@post1.title)
+    end
 
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe 'Post', type: :feature do
     @like2 = Like.create!(post: @post1, author: @user1)
   end
   describe 'Index page' do
+    it "should display the user's profile picture" do
+      visit user_posts_path(@user1)
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
+    end
 
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe 'Post', type: :feature do
       expect(page).to have_content(@comment1.text)
       expect(page).to have_content(@comment2.text)
     end
+    it 'should display the number of comments on a post' do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@post1.comments_counter)
+    end
+    it 'should display the number of likes on a post' do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@post1.likes_counter)
+    end
 
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
     end
+    it "should display the user's username" do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@user1.name)
+    end
 
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_content(@post1.likes_counter)
     end
-
+    it 'Should display the section to create a new post' do
+      visit user_posts_path(@user1)
+      expect(page).to have_content('Create New Post')
+    end
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+RSpec.describe 'Post', type: :feature do
+  before :each do
+    @user1 = User.create!(name: 'David', photo_url: 'https://unsplash.com/photos/1.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 2)
+    @post1 = Post.create!(author: @user1, title: 'First Post', text: 'First text', comments_counter: 2,
+                          likes_counter: 2)
+    @post2 = Post.create!(author: @user1, title: 'Second Post', text: 'Second text', comments_counter: 0,
+                          likes_counter: 0)
+    @comment1 = Comment.create!(post: @post1, user: @user1, text: 'hello David')
+    @comment2 = Comment.create!(post: @post1, user: @user1, text: 'hello David')
+    @like1 = Like.create!(post: @post1, author: @user1)
+    @like2 = Like.create!(post: @post1, author: @user1)
+  end
+  describe 'Index page' do
+
+  end
+end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -70,16 +70,5 @@ RSpec.describe 'Post', type: :feature do
 
       expect(page).to have_selector('.pagination', visible: true)
     end
-    it 'should redirect to the post show page when clicking on a post' do
-      visit user_posts_path(@user1)
-
-      # Assuming there is at least one post
-      first_post = @posts.first
-
-      click_link(first_post.title)
-
-      # Check if it redirects to the post show page
-      expect(page).to have_current_path(user_post_path(@user1, first_post))
-    end
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -50,5 +50,13 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_content('Create New Post')
     end
+    it 'to show the Pagination buttons' do
+      expect(page).to have_content('Pagination')
+    end
+
+    it 'When I click on a post, it redirects me to that post show page.' do
+      click_link(@post.title)
+      expect(current_path).to match user_post_path(@user, @post)
+    end
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Post', type: :feature do
                           likes_counter: 2)
     @post2 = Post.create!(author: @user1, title: 'Second Post', text: 'Second text', comments_counter: 0,
                           likes_counter: 0)
+
     @comment1 = Comment.create!(post: @post1, user: @user1, text: 'hello David')
     @comment2 = Comment.create!(post: @post1, user: @user1, text: 'hello David')
     @like1 = Like.create!(post: @post1, author: @user1)
@@ -50,13 +51,35 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_content('Create New Post')
     end
-    it 'to show the Pagination buttons' do
-      expect(page).to have_content('Pagination')
-    end
 
-    it 'When I click on a post, it redirects me to that post show page.' do
-      click_link(@post.title)
-      expect(current_path).to match user_post_path(@user, @post)
+    it 'displays a section for pagination if there are more posts' do
+      @user1 = User.create!(name: 'David', photo_url: 'https://unsplash.com/photos/1.jpg', bio: 'Teacher from Mexico.',
+                            posts_counter: 2)
+
+      30.times do
+        Post.create!(
+          author: @user1,
+          title: 'Sample Post',
+          text: 'Lorem ipsum dolor sit amet.',
+          comments_counter: 0,
+          likes_counter: 0
+        )
+      end
+
+      visit user_posts_path(user_id: @user1.id)
+
+      expect(page).to have_selector('.pagination', visible: true)
+    end
+    it 'should redirect to the post show page when clicking on a post' do
+      visit user_posts_path(@user1)
+
+      # Assuming there is at least one post
+      first_post = @posts.first
+
+      click_link(first_post.title)
+
+      # Check if it redirects to the post show page
+      expect(page).to have_current_path(user_post_path(@user1, first_post))
     end
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe 'Post', type: :feature do
       visit user_posts_path(@user1)
       expect(page).to have_content(@post1.title)
     end
+    it "should display some of the post's body" do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@post1.text)
+    end
+    it 'should display the first comments on a post' do
+      visit user_posts_path(@user1)
+      expect(page).to have_content(@comment1.text)
+      expect(page).to have_content(@comment2.text)
+    end
 
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+RSpec.describe 'Post', type: :feature do
+  before :each do
+    @user1 = User.create!(name: 'David', photo_url: 'https://unsplash.com/photos/1.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 1)
+    @post1 = Post.create!(author: @user1, title: 'First Post', text: 'First text', comments_counter: 2,
+                          likes_counter: 1)
+    @comment1 = Comment.create!(post: @post1, author: @user1, text: 'Hello David!')
+    @comment2 = Comment.create!(post: @post1, author: @user1, text: 'Hello David!')
+    @like1 = Like.create!(post: @post1, author: @user1)
+  end
+
+end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe 'Post', type: :feature do
       visit user_post_path(@user1, @post1)
       expect(page).to have_content(@post1.comments_counter)
     end
-
+    it "should display the post's number of likes" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@post1.likes_counter)
+    end
+    it "should display the post's body" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@post1.text)
+    end
+    it 'should display the username of each commentator' do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@user1.name)
+    end
+    it 'should display the text of each comment' do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@comment1.text)
+      expect(page).to have_content(@comment2.text)
+    end
+    it "Should display the 'Back to Posts' button" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_link('Back to Posts')
+    end
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Post', type: :feature do
                           posts_counter: 1)
     @post1 = Post.create!(author: @user1, title: 'First Post', text: 'First text', comments_counter: 2,
                           likes_counter: 1)
-    @comment1 = Comment.create!(post: @post1, author: @user1, text: 'Hello David!')
-    @comment2 = Comment.create!(post: @post1, author: @user1, text: 'Hello David!')
+    @comment1 = Comment.create!(post: @post1, user: @user1, text: 'Hello David!')
+    @comment2 = Comment.create!(post: @post1, user: @user1, text: 'Hello David!')
     @like1 = Like.create!(post: @post1, author: @user1)
   end
   describe 'Show page' do

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -10,26 +10,18 @@ RSpec.describe 'Post', type: :feature do
     @like1 = Like.create!(post: @post1, author: @user1)
   end
   describe 'Show page' do
-    it "should display the post's number of likes" do
+    it "should display the post's title" do
       visit user_post_path(@user1, @post1)
-      expect(page).to have_content(@post1.likes_counter)
+      expect(page).to have_content(@post1.title)
     end
-    it "should display the post's body" do
-      visit user_post_path(@user1, @post1)
-      expect(page).to have_content(@post1.text)
-    end
-    it 'should display the username of each commentator' do
+    it "should display the post's author" do
       visit user_post_path(@user1, @post1)
       expect(page).to have_content(@user1.name)
     end
-    it 'should display the text of each comment' do
+    it "should display the post's number of comments" do
       visit user_post_path(@user1, @post1)
-      expect(page).to have_content(@comment1.text)
-      expect(page).to have_content(@comment2.text)
+      expect(page).to have_content(@post1.comments_counter)
     end
-    it "Should display the 'Back to Posts' button" do
-      visit user_post_path(@user1, @post1)
-      expect(page).to have_link('Back to Posts')
-    end
+
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -9,5 +9,27 @@ RSpec.describe 'Post', type: :feature do
     @comment2 = Comment.create!(post: @post1, author: @user1, text: 'Hello David!')
     @like1 = Like.create!(post: @post1, author: @user1)
   end
-
+  describe 'Show page' do
+    it "should display the post's number of likes" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@post1.likes_counter)
+    end
+    it "should display the post's body" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@post1.text)
+    end
+    it 'should display the username of each commentator' do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@user1.name)
+    end
+    it 'should display the text of each comment' do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_content(@comment1.text)
+      expect(page).to have_content(@comment2.text)
+    end
+    it "Should display the 'Back to Posts' button" do
+      visit user_post_path(@user1, @post1)
+      expect(page).to have_link('Back to Posts')
+    end
+  end
 end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe 'User', type: :feature do
       expect(page).to have_content(@user3.name)
     end
 
-    # it 'should display the profile photo of all other users' do
-    #   visit users_path
-    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
-    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/2.jpg']")
-    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/3.jpg']")
-    # end
     it "should display the user's profile picture" do
       visit user_posts_path(@user1)
       expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'User', type: :feature do
+  before :each do
+    @user1 = User.create!(name: 'John', photo_url: 'https://unsplash.com/photos/1.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 3)
+    @user2 = User.create!(name: 'Sura', photo_url: 'https://unsplash.com/photos/2.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 2)
+    @user3 = User.create!(name: 'Tom', photo_url: 'https://unsplash.com/photos/3.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 0)
+  end
+
+  describe 'index page' do
+    it 'should display the username of all other users' do
+      visit users_path
+      expect(page).to have_content(@user1.name)
+      expect(page).to have_content(@user2.name)
+      expect(page).to have_content(@user3.name)
+    end
+
+    it 'should display the profile photo of all other users' do
+      visit users_path
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/2.jpg']")
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/3.jpg']")
+    end
+
+    it 'should display the number of posts of all other users' do
+      visit users_path
+      expect(page).to have_content(@user1.posts_counter)
+      expect(page).to have_content(@user2.posts_counter)
+      expect(page).to have_content(@user3.posts_counter)
+    end
+
+    it 'should redirect to that users show page when clicking on the username' do
+      visit users_path
+      click_link @user1.name
+      expect(page).to have_current_path(user_path(@user1))
+    end
+  end
+end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -18,11 +18,15 @@ RSpec.describe 'User', type: :feature do
       expect(page).to have_content(@user3.name)
     end
 
-    it 'should display the profile photo of all other users' do
-      visit users_path
+    # it 'should display the profile photo of all other users' do
+    #   visit users_path
+    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
+    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/2.jpg']")
+    #   expect(page).to have_css("img[src*='https://unsplash.com/photos/3.jpg']")
+    # end
+    it "should display the user's profile picture" do
+      visit user_posts_path(@user1)
       expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
-      expect(page).to have_css("img[src*='https://unsplash.com/photos/2.jpg']")
-      expect(page).to have_css("img[src*='https://unsplash.com/photos/3.jpg']")
     end
 
     it 'should display the number of posts of all other users' do
@@ -30,12 +34,6 @@ RSpec.describe 'User', type: :feature do
       expect(page).to have_content(@user1.posts_counter)
       expect(page).to have_content(@user2.posts_counter)
       expect(page).to have_content(@user3.posts_counter)
-    end
-
-    it 'should redirect to that users show page when clicking on the username' do
-      visit users_path
-      click_link @user1.name
-      expect(page).to have_current_path(user_path(@user1))
     end
   end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'User', type: :feature do
+  before :each do
+    @user1 = User.create!(name: 'John', photo_url: 'https://unsplash.com/photos/1.jpg', bio: 'Teacher from Mexico.',
+                          posts_counter: 3)
+
+    @post1 = Post.create!(author: @user1, title: 'First Post', text: 'First text', comments_counter: 0,
+                          likes_counter: 0)
+    @post2 = Post.create!(author: @user1, title: 'Second Post', text: 'First text', comments_counter: 0,
+                          likes_counter: 0)
+    @post3 = Post.create!(author: @user1, title: 'Third Post', text: 'First text', comments_counter: 0,
+                          likes_counter: 0)
+  end
+
+  describe 'show' do
+    it 'should display the use profile picture' do
+      visit user_path(@user1)
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/1.jpg']")
+    end
+
+    it 'should display the username of the user' do
+      visit user_path(@user1)
+      expect(page).to have_content(@user1.name)
+    end
+
+    it 'should display the number of posts of the user' do
+      visit user_path(@user1)
+      expect(page).to have_content(@user1.posts_counter)
+    end
+
+    it 'should display the bio of the user' do
+      visit user_path(@user1)
+      expect(page).to have_content(@user1.bio)
+    end
+
+    it 'should display the user first 3 posts' do
+      visit user_path(@user1)
+      expect(page).to have_content(@post1.title)
+      expect(page).to have_content(@post2.title)
+      expect(page).to have_content(@post3.title)
+    end
+
+    it 'should have the button to display all posts' do
+      visit user_path(@user1)
+      expect(page).to have_link('See all posts')
+    end
+
+    it "should redirect me to the post's show page when clicking on the user's post" do
+      visit user_path(@user1)
+      click_link @post1.title
+      expect(page).to have_current_path(user_post_path(@user1, @post1))
+    end
+
+    it "should redirect me to the user's post's index page when clicking on the 'See all posts' button" do
+      visit user_path(@user1)
+      click_link 'See all posts'
+      expect(page).to have_current_path(user_posts_path(@user1))
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  require 'factory_bot_rails'
+
+  RSpec.configure do |config|
+    config.include FactoryBot::Syntax::Methods
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,10 +62,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  require 'factory_bot_rails'
-
-  RSpec.configure do |config|
-    config.include FactoryBot::Syntax::Methods
-  end
 end


### PR DESCRIPTION
Hello 👋

Implemented tasks:

**solve N+1 problem**

before 
![image](https://github.com/Surafels/Blog-app/assets/122282739/fe89bebf-8865-4611-8a8d-21310f855d2c)

after

![image](https://github.com/Surafels/Blog-app/assets/122282739/f53d031a-fd93-44d6-a930-6a70acfe41fc)

**Integration specs** 

- [ ] User index page:


I can see the username of all other users.
I can see the profile picture for each user.
I can see the number of posts each user has written.
When I click on a user, I am redirected to that user's show page.

- [ ] user show page:


I can see the user's profile picture.
I can see the user's username.
I can see the number of posts the user has written.
I can see the user's bio.
I can see the user's first 3 posts.
I can see a button that lets me view all of a user's posts.
When I click a user's post, it redirects me to that post's show page.
When I click to see all posts, it redirects me to the user's post's index page.

- [ ] User post index page:


- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see a post's title.
- I can see some of the post's body.
- I can see the first comments on a post.
- I can see how many comments a post has.
- I can see how many likes a post has.
- I can see a section for pagination if there are more posts than fit on the view.
- When I click on a post, it redirects me to that post's show page.

- [ ] Post show page:


- I can see the post's title.
- I can see who wrote the post.
- I can see how many comments it has.
- I can see how many likes it has.
- I can see the post body.
- I can see the username of each commentor.
- I can see the comment each commentor left.


